### PR TITLE
Rename `Amount` to `SignedAmount`

### DIFF
--- a/src/v2/generated.rs
+++ b/src/v2/generated.rs
@@ -1597,7 +1597,7 @@ pub struct MinaBaseAccountUpdateBodyStableV1 {
     pub public_key: NonZeroCurvePoint,
     pub token_id: TokenIdKeyHash,
     pub update: MinaBaseAccountUpdateUpdateStableV1,
-    pub balance_change: Amount,
+    pub balance_change: SignedAmount,
     pub increment_nonce: bool,
     pub events: MinaBaseAccountUpdateBodyEventsStableV1,
     pub actions: MinaBaseAccountUpdateBodyEventsStableV1,
@@ -2046,8 +2046,8 @@ pub struct MinaTransactionLogicZkappCommandLogicLocalStateValueStableV1 {
     pub transaction_commitment: crate::bigint::BigInt,
     pub full_transaction_commitment: crate::bigint::BigInt,
     pub token_id: TokenIdKeyHash,
-    pub excess: Amount,
-    pub supply_increase: Amount,
+    pub excess: SignedAmount,
+    pub supply_increase: SignedAmount,
     pub ledger: LedgerHash,
     pub success: bool,
     pub account_update_index: UnsignedExtendedUInt32StableV1,
@@ -2281,7 +2281,7 @@ pub struct MinaStateBlockchainStateValueStableV2LedgerProofStatement {
     pub target: MinaStateBlockchainStateValueStableV2LedgerProofStatementSource,
     pub connecting_ledger_left: LedgerHash,
     pub connecting_ledger_right: LedgerHash,
-    pub supply_increase: Amount,
+    pub supply_increase: SignedAmount,
     pub fee_excess: MinaBaseFeeExcessStableV1,
     pub sok_digest: (),
 }
@@ -2310,7 +2310,7 @@ pub struct MinaStateSnarkedLedgerStateWithSokStableV2 {
     pub target: MinaStateBlockchainStateValueStableV2LedgerProofStatementSource,
     pub connecting_ledger_left: LedgerHash,
     pub connecting_ledger_right: LedgerHash,
-    pub supply_increase: Amount,
+    pub supply_increase: SignedAmount,
     pub fee_excess: MinaBaseFeeExcessStableV1,
     pub sok_digest: MinaBaseZkappAccountZkappUriStableV1,
 }
@@ -2669,6 +2669,7 @@ pub struct NetworkPoolSnarkPoolDiffVersionedStableV2AddSolvedWork1 {
 /// Derived name: `Transaction_snark_scan_state.Stable.V2.previous_incomplete_zkapp_updates.1`
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 #[polymorphic_variant]
+#[allow(non_camel_case_types)]
 pub enum TransactionSnarkScanStateStableV2PreviousIncompleteZkappUpdates1 {
     Border_block_continued_in_the_next_tree(bool),
 }

--- a/src/v2/hashing.rs
+++ b/src/v2/hashing.rs
@@ -23,7 +23,7 @@ use crate::{
 };
 
 use super::{
-    generated, Amount, ConsensusBodyReferenceStableV1, ConsensusGlobalSlotStableV1,
+    generated, SignedAmount, ConsensusBodyReferenceStableV1, ConsensusGlobalSlotStableV1,
     ConsensusProofOfStakeDataConsensusStateValueStableV1,
     ConsensusProofOfStakeDataEpochDataNextValueVersionedValueStableV1,
     ConsensusProofOfStakeDataEpochDataStakingValueVersionedValueStableV1,
@@ -588,9 +588,9 @@ impl ToInput for MinaStateBlockchainStateValueStableV2LedgerProofStatementSource
     }
 }
 
-impl ToInput for Amount {
+impl ToInput for SignedAmount {
     fn to_input(&self, inputs: &mut Inputs) {
-        let Amount { magnitude, sgn } = self;
+        let SignedAmount { magnitude, sgn } = self;
         to_input_fields!(inputs, magnitude, sgn);
     }
 }

--- a/src/v2/manual.rs
+++ b/src/v2/manual.rs
@@ -688,7 +688,7 @@ mod tests_sgn {
 /// Location: [src/lib/currency/signed_poly.ml:6:4](https://github.com/Minaprotocol/mina/blob/b1facec/src/lib/currency/signed_poly.ml#L6)
 /// Args: CurrencyFeeStableV1 , SgnStableV1
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
-pub struct Amount {
+pub struct SignedAmount {
     pub magnitude: CurrencyFeeStableV1,
     pub sgn: SgnStableV1,
 }
@@ -708,7 +708,7 @@ pub struct MinaBaseFeeExcessStableV1(pub TokenFeeExcess, pub TokenFeeExcess);
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
 pub struct TokenFeeExcess {
     pub token: TokenIdKeyHash,
-    pub amount: Amount,
+    pub amount: SignedAmount,
 }
 
 impl Default for NonZeroCurvePointUncompressedStableV1 {


### PR DESCRIPTION
In OCaml, "amount" and "signed amount" are 2 distinct types.
Rename `Amount` to `SignedAmount` to avoid confusion, since that type contains the sign